### PR TITLE
Add an Arch version

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -1,5 +1,5 @@
 [Distribution]
-Distribution=fedora
+@Distribution=fedora
 
 # Update this to your current systemd checkout on the host
 [Host]
@@ -17,86 +17,3 @@ ImageId=diskomator
 KernelCommandLine=ip=dhcp systemd.unit=storage-target-mode.target systemd.debug_shell quiet splash selinux=0 systemd.set_credential=firstboot.timezone:UTC
 Bootable=yes
 WithDocs=no
-Packages=
-        audit-libs
-        cryptsetup-libs
-        gnutls
-        intel-gpu-firmware
-        iwlwifi-mvm-firmware
-        kernel
-        libbpf
-        libgcrypt
-        libxcrypt
-        libxkbcommon
-        linux-firmware
-        microcode_ctl
-        openssh-server
-        openssl-libs
-        plymouth
-        plymouth-system-theme
-        qrencode-libs
-        systemd
-        systemd-boot-unsigned
-        tpm2-tss
-        util-linux
-        wireless-regdb
-
-BuildPackages=
-        /usr/bin/pkg-config
-        acl
-        bpftool
-        diff
-        docbook-xsl
-        findutils
-        gcc
-        git
-        gperf
-        libgcrypt-devel
-        libxslt
-        meson
-        ninja
-        pam-devel
-        pkgconfig(audit)
-        pkgconfig(blkid)
-        pkgconfig(bzip2)
-        pkgconfig(dbus-1)
-        pkgconfig(fdisk)
-        pkgconfig(glib-2.0)
-        pkgconfig(gnutls)
-        pkgconfig(libacl)
-        pkgconfig(libbpf)
-        pkgconfig(libcap)
-        pkgconfig(libcryptsetup)
-        pkgconfig(libcurl)
-        pkgconfig(libdw)
-        pkgconfig(libfido2)
-        pkgconfig(libidn2)
-        pkgconfig(libkmod)
-        pkgconfig(libmicrohttpd)
-        pkgconfig(libnftnl)
-        pkgconfig(libpcre2-8)
-        pkgconfig(libqrencode)
-        pkgconfig(libseccomp)
-        pkgconfig(libselinux)
-        pkgconfig(libzstd)
-        pkgconfig(mount)
-        pkgconfig(numa)
-        pkgconfig(openssl)
-        pkgconfig(openssl)
-        pkgconfig(p11-kit-1)
-        pkgconfig(pwquality)
-        pkgconfig(tss2-esys)
-        pkgconfig(tss2-mu)
-        pkgconfig(tss2-rc)
-        pkgconfig(tss2-tcti-device)
-        pkgconfig(valgrind)
-        pkgconfig(xencontrol)
-        pkgconfig(xkbcommon)
-        python3
-        python3dist(jinja2)
-        python3dist(lxml)
-        python3dist(pefile)
-        python3dist(pyelftools)
-        python3dist(pytest)
-        python3dist(pytest-flakes)
-        rpm

--- a/mkosi.conf.d/20-arch.conf
+++ b/mkosi.conf.d/20-arch.conf
@@ -1,0 +1,77 @@
+[Match]
+Distribution=arch
+
+[Host]
+# The Arch image is rather big and needs more memory to start
+QemuMem=3G
+
+[Content]
+Packages=
+        amd-ucode
+        audit
+        bash
+        cryptsetup
+        diffutils
+        gawk
+        gnutls
+        intel-ucode
+        libbpf
+        libgcrypt
+        libxcrypt
+        libxkbcommon
+        linux
+        linux-firmware
+        mesa
+        openssh
+        plymouth
+        qrencode
+        sed
+        systemd
+        tpm2-tss
+        util-linux
+        wireless-regdb
+
+BuildPackages=
+        acl
+        audit
+        bash-completion
+        bpf
+        clang
+        cryptsetup
+        curl
+        docbook-xsl
+        git
+        gnutls
+        gperf
+        intltool
+        iptables
+        kexec-tools
+        kmod
+        lib32-gcc-libs
+        libcap
+        libelf
+        libfido2
+        libgcrypt
+        libidn2
+        libmicrohttpd
+        libseccomp
+        libxcrypt
+        libxkbcommon
+        libxslt
+        linux-api-headers
+        llvm
+        lz4
+        meson
+        p11-kit
+        pam
+        pcre2
+        pkgconf
+        python-jinja
+        python-lxml
+        python-pyelftools
+        quota-tools
+        rsync
+        shadow
+        systemd
+        util-linux
+        xz

--- a/mkosi.conf.d/20-fedora.conf
+++ b/mkosi.conf.d/20-fedora.conf
@@ -1,0 +1,87 @@
+[Match]
+Distribution=fedora
+
+[Content]
+Packages=
+        audit-libs
+        cryptsetup-libs
+        gnutls
+        intel-gpu-firmware
+        iwlwifi-mvm-firmware
+        kernel
+        libbpf
+        libgcrypt
+        libxcrypt
+        libxkbcommon
+        linux-firmware
+        microcode_ctl
+        openssh-server
+        openssl-libs
+        plymouth
+        plymouth-system-theme
+        qrencode-libs
+        systemd
+        systemd-boot-unsigned
+        tpm2-tss
+        util-linux
+        wireless-regdb
+
+BuildPackages=
+        /usr/bin/pkg-config
+        acl
+        bpftool
+        diff
+        docbook-xsl
+        findutils
+        gcc
+        git
+        gperf
+        libgcrypt-devel
+        libxslt
+        meson
+        ninja
+        pam-devel
+        pkgconfig(audit)
+        pkgconfig(blkid)
+        pkgconfig(bzip2)
+        pkgconfig(dbus-1)
+        pkgconfig(fdisk)
+        pkgconfig(glib-2.0)
+        pkgconfig(gnutls)
+        pkgconfig(libacl)
+        pkgconfig(libbpf)
+        pkgconfig(libcap)
+        pkgconfig(libcryptsetup)
+        pkgconfig(libcurl)
+        pkgconfig(libdw)
+        pkgconfig(libfido2)
+        pkgconfig(libidn2)
+        pkgconfig(libkmod)
+        pkgconfig(libmicrohttpd)
+        pkgconfig(libnftnl)
+        pkgconfig(libpcre2-8)
+        pkgconfig(libqrencode)
+        pkgconfig(libseccomp)
+        pkgconfig(libselinux)
+        pkgconfig(libzstd)
+        pkgconfig(mount)
+        pkgconfig(numa)
+        pkgconfig(openssl)
+        pkgconfig(openssl)
+        pkgconfig(p11-kit-1)
+        pkgconfig(pwquality)
+        pkgconfig(tss2-esys)
+        pkgconfig(tss2-mu)
+        pkgconfig(tss2-rc)
+        pkgconfig(tss2-tcti-device)
+        pkgconfig(valgrind)
+        pkgconfig(xencontrol)
+        pkgconfig(xkbcommon)
+        python3
+        python3dist(jinja2)
+        python3dist(lxml)
+        python3dist(pefile)
+        python3dist(pyelftools)
+        python3dist(pytest)
+        python3dist(pytest-flakes)
+        rpm


### PR DESCRIPTION
Can be built by specifying `-d arch`. Tested it in qemu and I copied the EFI binary on a physical machine and bootet it successfully there. Haven't tried the actual functionality of the storage mode yet, though. Also booting from a USB stick I burnt this to didn't work on the physical machine I tested, but I don't know yet whether this is an issue with the stick, the firmware of the machine or the image. 